### PR TITLE
Add CPT and ICD10 codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,22 @@
 
 Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
 
-<!--
+## Overview
 
-Developer TODO: Update the below as needed to correctly describe the install procedure. For instance, if you do not have a PyPi repo, or if you want users to directly install from your git repo, you can modify this step as appropriate.
+This tap currently supports:
 
-## Installation
-
-Install from PyPi:
-
-```bash
-pipx install tap-healthie
-```
-
-Install from GitHub:
-
-```bash
-pipx install git+https://github.com/ORG_NAME/tap-healthie.git@main
-```
-
--->
+* Appointment Types
+* CPT Codes
+* ICD10 Codes
+* Users (clients)
+  * Appointments
+  * Charting Items
+    * Form Answer Groups
+      * Auto-scored Sections
+      * Charting Note Addendums
+      * Form Answer Group Signings
+      * Form Answers
+* Organization Members
 
 ## Configuration
 
@@ -64,6 +61,24 @@ Developer TODO: If your tap requires special access on the source system, or any
 -->
 
 ## Usage
+
+<!--
+Developer TODO: Update the below as needed to correctly describe the install procedure. For instance, if you do not have a PyPi repo, or if you want users to directly install from your git repo, you can modify this step as appropriate.
+
+## Installation
+
+Install from PyPi:
+
+```bash
+pipx install tap-healthie
+```
+
+Install from GitHub:
+
+```bash
+pipx install git+https://github.com/ORG_NAME/tap-healthie.git@main
+```
+-->
 
 You can easily run `tap-healthie` by itself or in a pipeline using [Meltano](https://meltano.com/).
 

--- a/tap_healthie/queries/queries.py
+++ b/tap_healthie/queries/queries.py
@@ -260,3 +260,33 @@ ORGANIZATION_MEMBERS_QUERY = """
         }
     }
 """
+
+CPT_CODES_QUERY = """
+    query ($offset: Int) {
+        cptCodesCount
+        cptCodes(offset: $offset, should_paginate: true) {
+            code
+            created_at
+            description
+            display_name
+            id
+            is_favorite
+            updated_at
+        }
+    }
+"""
+
+ICD10_CODES_QUERY = """
+    query ($offset: Int) {
+        icdCodesCount
+        icdCodes(offset: $offset, should_paginate: true) {
+            code
+            created_at
+            description
+            display_name
+            id
+            is_favorite
+            updated_at
+        }
+    }
+"""

--- a/tap_healthie/queries/schemas.py
+++ b/tap_healthie/queries/schemas.py
@@ -319,3 +319,23 @@ USERS_SCHEMA = PropertiesList(
     Property("true_human_id", StringType),
     Property("updated_at", StringType),
 )
+
+CPT_CODES_SCHEMA = PropertiesList(
+    Property("code", StringType),
+    Property("created_at", StringType),
+    Property("description", StringType),
+    Property("display_name", StringType),
+    Property("id", StringType, required=True),
+    Property("is_favorite", BooleanType),
+    Property("updated_at", StringType),
+)
+
+ICD10_CODES_SCHEMA = PropertiesList(
+    Property("code", StringType),
+    Property("created_at", StringType),
+    Property("description", StringType),
+    Property("display_name", StringType),
+    Property("id", StringType, required=True),
+    Property("is_favorite", BooleanType),
+    Property("updated_at", StringType),
+)

--- a/tap_healthie/streams.py
+++ b/tap_healthie/streams.py
@@ -82,3 +82,25 @@ class OrganizationMembersStream(HealthieStream):
     primary_keys = ["id"]
     records_jsonpath = f"$.data.{query_name}[*]"
     query = queries.ORGANIZATION_MEMBERS_QUERY
+
+
+class CPTCodesStream(HealthieStream):
+    """CPT Codes stream."""
+
+    name = "cpt_codes"
+    query_name = "cptCodes"
+    schema = schemas.CPT_CODES_SCHEMA.to_dict()
+    primary_keys = ["id"]
+    records_jsonpath = f"$.data.{query_name}[*]"
+    query = queries.CPT_CODES_QUERY
+
+
+class ICD10CodesStream(HealthieStream):
+    """ICD10 Codes stream."""
+
+    name = "icd_codes"
+    query_name = "icdCodes"
+    schema = schemas.ICD10_CODES_SCHEMA.to_dict()
+    primary_keys = ["id"]
+    records_jsonpath = f"$.data.{query_name}[*]"
+    query = queries.ICD10_CODES_QUERY

--- a/tap_healthie/tap.py
+++ b/tap_healthie/tap.py
@@ -40,6 +40,8 @@ class TapHealthie(Tap):
             streams.OrganizationMembersStream(self),
             streams.UsersStream(self),
             streams.ChartingItemsStream(self),
+            streams.CPTCodesStream(self),
+            streams.ICD10CodesStream(self),
         ]
 
 


### PR DESCRIPTION
* Adds queries and schemas for both CPT and ICD10 codes
* Updates the README to show a list of the objects this tap pulls

We need to pull the CPT and ICD10 codes because in a charting note->form answer group->form answer if it's related to a CPT or ICD10 code, healthie stores the internal ID of both the CPT and ICD10 codes, and we need to know what those actually are at the end of the day.